### PR TITLE
对 Config 的路径说明错误修正（转义问题）

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -186,7 +186,7 @@ module.exports = {
                    另外，如果使用酷Q的話，您需要定期自行清理酷Q的快取！
                  */
                 "type": "",                     // 檔案的處置方式：省略/留空/none、self、vim-cn、linx
-                "coolqCache": "",               // 酷Q快取存放位置，例如 /home/coolq/CoolQ/data（如果為*nix伺服器）或 C:\CoolQ\data（如果為Windows伺服器）
+                "coolqCache": "",               // 酷Q快取存放位置，例如 /home/coolq/CoolQ/data（如果為*nix伺服器）或 C:\\CoolQ\\data（如果為Windows伺服器）
                 "cachePath": "",                // type為self時有效：快取存放位置
                 "serveUrl": "",                 // type為self時有效：檔案URL的字首，一般需要以斜線結尾
                 "linxApiUrl": "",               // type為linx時有效：linx API位址，一般以斜線結尾


### PR DESCRIPTION
事实上路径的「\」也要转义，不然会读取机器人程序目录。